### PR TITLE
Troubleshoot document retrieval for chatbot

### DIFF
--- a/retrieval.py
+++ b/retrieval.py
@@ -15,7 +15,17 @@ load_dotenv()
 # Initialize Pinecone
 pc = Pinecone(api_key=os.environ.get("PINECONE_API_KEY"))
 index_name = os.environ.get("PINECONE_INDEX_NAME")
-index = pc.Index(index_name)
+index_host = os.environ.get("PINECONE_INDEX_HOST")
+
+try:
+    if index_host:
+        index = pc.Index(index_name, host=index_host)
+    else:
+        desc = pc.describe_index(index_name)
+        host = desc.get("host") if isinstance(desc, dict) else getattr(desc, "host", None)
+        index = pc.Index(index_name, host=host) if host else pc.Index(index_name)
+except Exception:
+    index = pc.Index(index_name)
 
 # Dùng HuggingFaceEmbeddings miễn phí (same model with ingestion)
 embeddings = HuggingFaceEmbeddings(


### PR DESCRIPTION
Fix document retrieval by synchronizing embedding models, enabling PDF ingestion from a directory, and improving Pinecone index initialization.

The previous setup failed to ingest documents on Linux due to a hardcoded Windows JSON path and had a mismatch in embedding models between ingestion and retrieval. Additionally, strict `PINECONE_INDEX_HOST` requirements caused errors if the environment variable was not set. These changes ensure proper document ingestion and retrieval by addressing these core issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-f19b5a18-e91a-4ee2-8c73-a4d061913768">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f19b5a18-e91a-4ee2-8c73-a4d061913768">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

